### PR TITLE
Adding reportOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module.exports = {
       resolve: `gatsby-plugin-csp`,
       options: {
         disableOnDev: true,
+        reportOnly: false, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
         mergeScriptHashes: true, // you can disable scripts sha256 hashes
         mergeStyleHashes: true, // you can disable styles sha256 hashes
         mergeDefaultDirectives: true,

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -19,6 +19,7 @@ exports.onPreRenderHTML = (
 ) => {
   const {
     disableOnDev = true,
+    reportOnly = false,
     mergeScriptHashes = true,
     mergeStyleHashes = true,
     mergeDefaultDirectives = true,
@@ -58,7 +59,7 @@ exports.onPreRenderHTML = (
   };
 
   const cspComponent = React.createElement("meta", {
-    httpEquiv: "Content-Security-Policy",
+    httpEquiv: `${reportOnly ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy"}`,
     content: cspString(csp)
   });
 


### PR DESCRIPTION
Adding ability to set Report-Only csp option (false by default) to allow proper testing of gatsby csp directives. Non-breaking change.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only 

Referencing issue #5 